### PR TITLE
fix: xAPI compliance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,14 @@ $client = new ApiClient(
     isSandbox: true, // optional, default is false
 );
 
-$platform = new \Msaaq\Nelc\Common\Platform($identifier = 'platform-identifier', $name = 'platform-name', $language = \Msaaq\Nelc\Enums\Language::ARABIC); // required
+$platform = new \Msaaq\Nelc\Common\Platform(
+    identifier: 'platform-identifier',
+    name: 'platform-name',
+    language: \Msaaq\Nelc\Enums\Language::ARABIC,
+    nameInOtherLanguages: [
+        \Msaaq\Nelc\Enums\Language::ENGLISH->value => 'platform-name-en', // optional, bilingual platform name
+    ],
+); // required
 ```
 
 After we created our client, we can use it to send statements to the NELC LRS.
@@ -154,6 +161,13 @@ $statement->module->title = 'How to create professional course';
 $statement->module->description = 'This series will cover the most important principles of course making, marketing and content preparation.';
 $statement->module->language = $statement->language;
 $statement->module->activityType = ActivityType::COURSE;
+
+// NELC learner extensions (optional, sent when available)
+$statement->duration = 'PT02H30M00S'; // course duration in ISO 8601 format
+$statement->learnerMobileNo = '966555123456';
+$statement->learnerFullName = 'Student Name';
+$statement->learnerNationality = 'SA';
+$statement->dateOfBirth = '15/06/1995'; // dd/mm/YYYY format
 
 var_dump($statementClient->send($statement));
 ```

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -24,6 +24,7 @@ class ApiClient
             'headers' => [
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
+                'X-Experience-API-Version' => '1.0.3',
             ],
         ]);
     }

--- a/src/Enums/Extension.php
+++ b/src/Enums/Extension.php
@@ -21,4 +21,14 @@ enum Extension: string
     case JWS_CERTIFICATE_LOCATION = 'http://id.tincanapi.com/extension/jws-certificate-location';
 
     case PLATFORM = 'https://nelc.gov.sa/extensions/platform';
+
+    case DURATION = 'https://nelc.gov.sa/extensions/duration';
+
+    case LEARNER_MOBILE_NO = 'https://nelc.gov.sa/extensions/learner_mobile_no';
+
+    case LEARNER_FULL_NAME = 'https://nelc.gov.sa/extensions/learner_full_name';
+
+    case LEARNER_NATIONALITY = 'https://nelc.gov.sa/extensions/learner_nationality';
+
+    case DATE_OF_BIRTH = 'https://nelc.gov.sa/extensions/date_of_birth';
 }

--- a/src/Statements/CompletedStatement.php
+++ b/src/Statements/CompletedStatement.php
@@ -9,9 +9,9 @@ use Msaaq\Nelc\Interfaces\StatementInterface;
 
 class CompletedStatement extends BaseStatement implements StatementInterface
 {
-    public BrowserInformation|null $browserInformation = null;
+    public ?BrowserInformation $browserInformation = null;
 
-    public Module|null $parent = null;
+    public ?Module $parent = null;
 
     public function toArray(): array
     {
@@ -36,7 +36,10 @@ class CompletedStatement extends BaseStatement implements StatementInterface
         }
 
         if ($this->browserInformation) {
-            $array['context']['extensions'] = $this->browserInformation->toArray();
+            $array['context']['extensions'] = array_merge(
+                $array['context']['extensions'],
+                $this->browserInformation->toArray()
+            );
         }
 
         return $array;

--- a/src/Statements/RegisteredStatement.php
+++ b/src/Statements/RegisteredStatement.php
@@ -2,13 +2,46 @@
 
 namespace Msaaq\Nelc\Statements;
 
+use Msaaq\Nelc\Enums\Extension;
 use Msaaq\Nelc\Enums\Verb;
 use Msaaq\Nelc\Interfaces\StatementInterface;
 
 class RegisteredStatement extends BaseStatement implements StatementInterface
 {
+    public string $duration = '';
+
+    public string $learnerMobileNo = '';
+
+    public string $learnerFullName = '';
+
+    public string $learnerNationality = '';
+
+    public string $dateOfBirth = '';
+
     public function toArray(): array
     {
+        $extensions = $this->sharedExtensions();
+
+        if ($this->duration) {
+            $extensions[Extension::DURATION->value] = $this->duration;
+        }
+
+        if ($this->learnerMobileNo) {
+            $extensions[Extension::LEARNER_MOBILE_NO->value] = $this->learnerMobileNo;
+        }
+
+        if ($this->learnerFullName) {
+            $extensions[Extension::LEARNER_FULL_NAME->value] = $this->learnerFullName;
+        }
+
+        if ($this->learnerNationality) {
+            $extensions[Extension::LEARNER_NATIONALITY->value] = $this->learnerNationality;
+        }
+
+        if ($this->dateOfBirth) {
+            $extensions[Extension::DATE_OF_BIRTH->value] = $this->dateOfBirth;
+        }
+
         return [
             'verb' => [
                 'id' => Verb::REGISTERED->value,
@@ -20,7 +53,7 @@ class RegisteredStatement extends BaseStatement implements StatementInterface
                 'instructor' => $this->instructor->toArray(),
                 'platform' => $this->platform->identifier,
                 'language' => $this->language->value,
-                'extensions' => $this->sharedExtensions(),
+                'extensions' => $extensions,
             ],
             'timestamp' => $this->getTimestamp(),
         ];


### PR DESCRIPTION
## Summary
- Add required `X-Experience-API-Version: 1.0.3` header to all LRS requests (required by xAPI spec)
- Add NELC-specific learner extensions to `RegisteredStatement` (duration, mobile, full name, nationality, date of birth)
- Fix `CompletedStatement` bug where browser info overwrites platform extension instead of merging with `array_merge`
- Update README with new learner extension usage and bilingual platform constructor

## Test plan
- [ ] Verify xAPI version header is sent in requests
- [ ] Verify registered statement includes learner extensions when populated
- [ ] Verify completed statement with browser info still includes platform extension
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)